### PR TITLE
Add support for additional LLM providers

### DIFF
--- a/docs/src/content/docs/guides/getting-started.md
+++ b/docs/src/content/docs/guides/getting-started.md
@@ -5,97 +5,127 @@ description: Set up ZapCircle with your code base to get started with behavior-d
 
 This guide walks you through the basics of adding ZapCircle to your React-based web development project.
 
-# Important to know
+# Important to Know
 
-ZapCircle is a developer tool, and does not modify your production build or generate code at run time. You can review, modify, and test any generated code before adding it to source control - just like any other tool.
+ZapCircle is a developer tool that **does not modify your production build or run-time code**. It generates code based on your written behaviors and allows you to review, modify, and test it before adding it to source control.
 
-The ZapCircle tool also works with any React framework - such as Next or Remix/React Router - and does not require any changes or upgrades.
+ZapCircle works with any React framework, including **Next.js**, **Remix**, **Vite**, and others. It does not require changes to your application architecture.
 
-The current version of ZapCircle works with the [Open AI API](https://platform.openai.com/docs/overview), using your own API key. Please be aware of any privacy, security, or cost concerns associated with using this API with your code base.
+ZapCircle supports multiple LLM providers via [LangChain](https://www.langchain.com/). As of now, the following providers are supported:
+
+- ✅ OpenAI
+- ✅ Anthropic
+- ✅ Google (Gemini)
+- ✅ Local LLMs (via REST API, such as LM Studio or Ollama)
+
+> ⚠️ Each provider requires its own API key or URL. See below for configuration.
+
+---
 
 # Prerequisites
 
-To get started with ZapCircle, you'll need two things:
-* Your code, or an example project, with React components in either JSX or TSX format. This could be Next, React Router/Remix, or something else.
-* An OpenAI API Key - [Create an API Key here](https://platform.openai.com/api-keys)
+To get started with ZapCircle, you'll need:
 
+- A React project with components in `.jsx` or `.tsx` format
+- One or more API keys or endpoints for supported LLM providers (OpenAI, Anthropic, etc.)
 
-## Setting up ZapCircle
+---
+
+## Setting Up ZapCircle
 
 ### Step 1: Verify Installation
 
-You typically don't need to install ZapCircle as a development dependency in your project. Run the following command to check the CLI version:
+You don’t need to install ZapCircle globally. Instead, use `npx` to run the CLI directly:
 
 ```bash
 npx zapcircle --version
 ```
 
-You should see the version of ZapCircle appear in the command line output, confirming the CLI is installed and ready to use.
+If installed correctly, this will print the current version of ZapCircle.
 
 ---
 
 ### Step 2: Configure ZapCircle
 
-Run the following command to interactively set up your preferred LLM and API key:
+Run the configuration wizard:
 
 ```bash
 npx zapcircle configure
 ```
 
-You'll be prompted to provide:
+You’ll be prompted to set:
 
-1. Your preferred LLM (default: `openai`) - note, this is the only LLM supported with the current version.
-2. The large model name (default: `o1`).
-3. The small model name (default: `o1-mini`).
-4. Your LLM API key (if applicable).
+- Your **preferred LLM provider** (e.g., `openai`, `anthropic`, `google`, or `local`)
+- Your preferred **large** and **small** model names
+- API keys for any provider you'd like to use
+- (Optional) A base URL for a locally running LLM
 
-Example output:
+#### Example output:
 
 ```plaintext
-Configuring ZapCircle CLI...
+🛠️ Configuring ZapCircle CLI...
 
-Preferred LLM (openai): openai
-OpenAI large model (default: o1): o1
-OpenAI small model (default: o1-mini): o1-mini
-OpenAI API key: ********
+Preferred Provider (openai): openai
+Large model (default: gpt-4o): gpt-4o
+Small model (default: gpt-4o-mini): gpt-4o-mini
 
-Configuration saved to ~/.zapcircle/zapcircle.cli.toml
+🔑 Enter API keys for the providers you want to use.
+OpenAI API key (optional): sk-***********
+Anthropic API key (optional): 
+Google API key (optional): 
+Local LLM base URL (optional): http://localhost:1234
+
+✅ Configuration saved to ~/.zapcircle/zapcircle.cli.toml
+```
+
+Your configuration is stored in a TOML file at:
+
+```bash
+~/.zapcircle/zapcircle.cli.toml
 ```
 
 ---
 
 ### Step 3: Confirm Your Setup
 
-After configuring ZapCircle, you can confirm everything is set up correctly by running:
+Run the following command to confirm everything is correctly configured:
 
 ```bash
 npx zapcircle status
 ```
 
-This command will display:
+This will show:
 
-- The preferred LLM configured for your user.
-- Whether a project-specific configuration file (`zapcircle.config.toml`) exists.
-- Detailed settings for the user and project configuration.
+- The configured provider
+- Model names for large and small tasks
+- API key status for each provider
+- Local LLM settings (if applicable)
+- Whether a project-level config file is present
 
-Example output:
+#### Example Output:
 
 ```plaintext
-ZapCircle Configuration Status:
+📦 ZapCircle Configuration Status:
 
-User Configuration:
-  Preferred LLM: openai
-  Large Model: o1
-  Small Model: o1-mini
-  OpenAI API Key: Configured
+🔧 User Configuration:
+  Provider: openai
+  Large Model: gpt-4o
+  Small Model: gpt-4o-mini
+  API Keys:
+    OpenAI: ✅ Configured
+    Anthropic: ❌ Not Configured
+    Google: ❌ Not Configured
+    Local LLM: ✅ Configured (http://localhost:1234)
 
-Project Configuration: Not Found
+📁 Project Configuration: ❌ Not Found
+
+✅ Status check complete.
 ```
 
 ---
 
-# Next step
+# Next Step
 
-Now that you have ZapCircle setup for your project, you can start to use it as a development assistant.
+Now that ZapCircle is ready to use, you're just a few steps away from using behavior-driven development in your React project.
 
-Let's learn how to [create behaviors](/guides/create-behaviors) for an existing project in the next step of the tutorial.
+➡️ [Continue to Create Behaviors](/guides/create-behaviors)

--- a/docs/src/content/docs/reference/command-line.md
+++ b/docs/src/content/docs/reference/command-line.md
@@ -304,10 +304,11 @@ npx zapcircle configure
 ```
 
 **Prompts:**
-- Preferred LLM (default: `openai`).
-- Large model name (default: `gpt-4`).
-- Small model name (default: `gpt-3.5-turbo`).
-- OpenAI API key.
+- Preferred Provider (default: `openai`) - also `anthropic`, `google`, and `local`.
+- Large model name (default: `gpt-4o`).
+- Small model name (default: `gpt-4o-mini`).
+- API key for each Provider.
+- URL for local LLM
 
 **Example:**
 ```bash
@@ -315,15 +316,21 @@ npx zapcircle configure
 ```
 
 **Output:**
+
 ```plaintext
-Configuring ZapCircle CLI...
+🛠️ Configuring ZapCircle CLI...
 
-Preferred LLM (openai): openai
-OpenAI large model (default: o1): o1
-OpenAI small model (default: o1-mini): o1-mini
-OpenAI API key: ********
+Preferred Provider (openai): openai
+Large model (default: gpt-4o): gpt-4o
+Small model (default: gpt-4o-mini): gpt-4o-mini
 
-Configuration saved to ~/.zapcircle/zapcircle.cli.toml
+🔑 Enter API keys for the providers you want to use.
+OpenAI API key (optional): sk-***********
+Anthropic API key (optional): 
+Google API key (optional): 
+Local LLM base URL (optional): http://localhost:1234
+
+✅ Configuration saved to ~/.zapcircle/zapcircle.cli.toml
 ```
 
 ---
@@ -367,7 +374,7 @@ ZapCircle project initialized. Configuration file created at ./zapcircle.config.
 ### `status`
 **Description:**  
 Display the current ZapCircle configuration, including:
-- The user's preferred LLM.
+- The user's preferred LLM provider.
 - Whether a project configuration file is present.
 - Detailed settings for the project.
 
@@ -382,25 +389,25 @@ npx zapcircle status
 ```
 
 **Output:**
+
 ```plaintext
-ZapCircle Configuration Status:
+📦 ZapCircle Configuration Status:
 
-User Configuration:
-  Preferred LLM: openai
-  Large Model: o1
-  Small Model: o1-mini
-  OpenAI API Key: Configured
+🔧 User Configuration:
+  Provider: openai
+  Large Model: gpt-4o
+  Small Model: gpt-4o-mini
+  API Keys:
+    OpenAI: ✅ Configured
+    Anthropic: ❌ Not Configured
+    Google: ❌ Not Configured
+    Local LLM: ✅ Configured (http://localhost:1234)
 
-Project Configuration: Found
-  Prompt Settings:
-    All Prompts: Custom instruction
-    Analyze Prompts: Analyze-specific instruction
-    Generate Prompts: Generate-specific instruction
-  Filetype Generate Prompts:
-    jsx: JSX-specific instruction
+📁 Project Configuration: ❌ Not Found
 
-Status check complete.
+✅ Status check complete.
 ```
+
 
 ---
 ## Global Options

--- a/zapcircle-cli/package-lock.json
+++ b/zapcircle-cli/package-lock.json
@@ -1,16 +1,19 @@
 {
   "name": "zapcircle",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zapcircle",
-      "version": "0.1.9",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
+        "@langchain/anthropic": "^0.3.18",
         "@langchain/core": "^0.3.27",
+        "@langchain/google-genai": "^0.2.4",
+        "@langchain/google-vertexai": "^0.2.4",
         "@langchain/openai": "^0.3.16",
         "commander": "^13.0.0",
         "dotenv": "^16.4.7",
@@ -56,6 +59,33 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.37.0.tgz",
+      "integrity": "sha512-tHjX2YbkUBwEgg0JZU3EFSSAQPoK4qQR/NFYa8Vtzd5UAyXzZksCw2In69Rml4R/TyHPBfRYaLK35XiOe33pjw==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
+      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -1465,6 +1495,14 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.0.tgz",
+      "integrity": "sha512-fnEITCGEB7NdX0BhoYZ/cq/7WPZ1QS5IzJJfC3Tg/OwkvBetMiVJciyaan297OvE4B9Jg1xvo0zIazX/9sGu1Q==",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1978,6 +2016,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@langchain/anthropic": {
+      "version": "0.3.18",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.18.tgz",
+      "integrity": "sha512-+2Pk9AFV4aBUOAqPT0VOaH6YbcVZ/xGoI6/dCW+W4svqcWwW7NExkAHdUAO9q+h2sUBbHs4j9bzLXlRQLvJ03A==",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.37.0",
+        "fast-xml-parser": "^4.4.1",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
     "node_modules/@langchain/core": {
       "version": "0.3.27",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.27.tgz",
@@ -2020,6 +2075,78 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@langchain/google-common": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@langchain/google-common/-/google-common-0.2.4.tgz",
+      "integrity": "sha512-lHLoqpAFKf6JCbl/O/ol6MSSnv10feA0U+dh7J2jkaqsikTQQ6jw9gFmYw26JjfBui4HEl5PGnay44ghrHuSUQ==",
+      "dependencies": {
+        "uuid": "^10.0.0",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/google-gauth": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@langchain/google-gauth/-/google-gauth-0.2.4.tgz",
+      "integrity": "sha512-jzmugiPeYxnR2sf48Roz7lLUyfKvov2JbPPjlb0J2/igBCwu9wyFxoTFF9M1ZXcvYTOp1jNcDhfh7X4BPP6bNw==",
+      "dependencies": {
+        "@langchain/google-common": "^0.2.4",
+        "google-auth-library": "^9.15.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/google-genai": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.4.tgz",
+      "integrity": "sha512-2w/QZMbSRpo6plKilqXXAmhdq5mB1gaDwOeN1tVpKBOwKtxsH9jOzxukKhs3QvXmfy/xod/WWLajBXxU+63/Dw==",
+      "dependencies": {
+        "@google/generative-ai": "^0.24.0",
+        "uuid": "^11.1.0",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.17 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/google-genai/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/google-vertexai": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@langchain/google-vertexai/-/google-vertexai-0.2.4.tgz",
+      "integrity": "sha512-mNetXdVkN7IIMIM8+64zHOIUVMlOKFF0mUG1osxhbkMuERJkgUpUvoi8F0RnJEucz1Pu6Lb9pjK/bNoyFr1Tug==",
+      "dependencies": {
+        "@langchain/google-gauth": "~0.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
       }
     },
     "node_modules/@langchain/openai": {
@@ -3069,6 +3196,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -3324,6 +3459,14 @@
         }
       ]
     },
+    "node_modules/bignumber.js": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
+      "integrity": "sha512-EM7aMFTXbptt/wZdMlBv2t8IViwQL+h6SLHosp8Yf0dqJMTnY6iL32opnAB6kAdL0SZPuvcAzFr31o0c/R3/RA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -3398,6 +3541,11 @@
       "dependencies": {
         "node-int64": "^0.4.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -3922,7 +4070,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4044,6 +4191,14 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -4541,6 +4696,11 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4598,6 +4758,23 @@
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
       "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
       "dev": true
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
+      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.1.1"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.18.0",
@@ -4803,6 +4980,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4928,6 +5145,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gpt-tokenizer": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/gpt-tokenizer/-/gpt-tokenizer-2.9.0.tgz",
@@ -4943,6 +5184,18 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4970,6 +5223,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5183,7 +5448,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -5941,6 +6205,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -6019,6 +6291,25 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -7751,8 +8042,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8029,6 +8319,17 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ]
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/zapcircle-cli/package.json
+++ b/zapcircle-cli/package.json
@@ -3,7 +3,7 @@
   "author": {
     "name": "Jeff Linwood"
   },
-  "version": "0.1.9",
+  "version": "0.2.0",
   "license": "MIT",
   "homepage": "https://zapcircle.com/",
   "bin": {
@@ -50,6 +50,9 @@
     "@iarna/toml": "^2.2.5",
     "@langchain/core": "^0.3.27",
     "@langchain/openai": "^0.3.16",
+    "@langchain/anthropic": "^0.3.18",
+    "@langchain/google-genai": "^0.2.4",
+    "@langchain/google-vertexai": "^0.2.4",
     "commander": "^13.0.0",
     "dotenv": "^16.4.7",
     "fs-extra": "^11.2.0",

--- a/zapcircle-cli/src/commands/configure.ts
+++ b/zapcircle-cli/src/commands/configure.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as readline from "readline";
 import * as path from "path";
+import { loadUserConfig } from "../core/config";
+import { UserConfig } from "../types/config";
 
 export const configureZapCircle = async () => {
   const rl = readline.createInterface({
@@ -18,38 +20,81 @@ export const configureZapCircle = async () => {
     fs.mkdirSync(userConfigDir);
   }
 
-  console.log("Configuring ZapCircle CLI...\n");
+  const existingConfig: UserConfig = loadUserConfig();
 
-  const preferredLLM =
-    (await askQuestion("Preferred LLM (openai): ")) || "openai";
+  console.log("🛠️ Configuring ZapCircle CLI...\n");
+
+  const provider =
+    (await askQuestion(
+      `Preferred Provider (${existingConfig.provider || "openai"}): `,
+    )) || existingConfig.provider || "openai";
+
   const largeModel =
-    (await askQuestion("OpenAI large model (default: o1): ")) || "o1";
+    (await askQuestion(
+      `Large model (${existingConfig.models?.large || "gpt-4o"}): `,
+    )) || existingConfig.models?.large || "gpt-4o";
+
   const smallModel =
-    (await askQuestion("OpenAI small model (default: o1-mini): ")) || "o1-mini";
-  const apiKey = await askQuestion("OpenAI API key: ");
+    (await askQuestion(
+      `Small model (${existingConfig.models?.small || "gpt-4o-mini"}): `,
+    )) || existingConfig.models?.small || "gpt-4o-mini";
+
+  console.log("\n🔑 Enter API keys for the providers you want to use.");
+  const openaiKey =
+    (await askQuestion(
+      `OpenAI API key (${existingConfig.openai?.apiKey ? "already set" : "optional"}): `,
+    )) || existingConfig.openai?.apiKey || "";
+
+  const anthropicKey =
+    (await askQuestion(
+      `Anthropic API key (${existingConfig.anthropic?.apiKey ? "already set" : "optional"}): `,
+    )) || existingConfig.anthropic?.apiKey || "";
+
+  const googleKey =
+    (await askQuestion(
+      `Google API key (${existingConfig.google?.apiKey ? "already set" : "optional"}): `,
+    )) || existingConfig.google?.apiKey || "";
+
+  const localBaseUrl =
+    (await askQuestion(
+      `Local LLM base URL (${existingConfig.local?.baseUrl || "none"}): `,
+    )) || existingConfig.local?.baseUrl || "";
+
+  // Simple validation
+  const isValidURL = (url: string) =>
+    /^https?:\/\/[\w.-]+(:\d+)?(\/.*)?$/.test(url);
+
+  if (localBaseUrl && !isValidURL(localBaseUrl)) {
+    console.warn("⚠️  Warning: Local LLM base URL does not appear to be valid.");
+  }
 
   rl.close();
 
-  const config = {
-    preferredLLM,
-    models: {
-      large: largeModel,
-      small: smallModel,
-    },
-    apiKey,
-  };
+  // Prepare final config object
+  const configLines = [
+    `# ZapCircle CLI Configuration`,
+    `provider = "${provider}"`,
+    ``,
+    `[models]`,
+    `large = "${largeModel}"`,
+    `small = "${smallModel}"`,
+    ``,
+  ];
 
-  fs.writeFileSync(
-    userConfigPath,
-    `# ZapCircle CLI Configuration
-preferredLLM = "${config.preferredLLM}"
-apiKey = "${config.apiKey}"
+  if (openaiKey) {
+    configLines.push(`[openai]`, `apiKey = "${openaiKey}"`, ``);
+  }
+  if (anthropicKey) {
+    configLines.push(`[anthropic]`, `apiKey = "${anthropicKey}"`, ``);
+  }
+  if (googleKey) {
+    configLines.push(`[google]`, `apiKey = "${googleKey}"`, ``);
+  }
+  if (localBaseUrl) {
+    configLines.push(`[local]`, `baseUrl = "${localBaseUrl}"`, ``);
+  }
 
-[models]
-large = "${config.models.large}"
-small = "${config.models.small}"
-`,
-  );
+  fs.writeFileSync(userConfigPath, configLines.join("\n"));
 
-  console.log(`Configuration saved to ${userConfigPath}`);
+  console.log(`✅ Configuration saved to ${userConfigPath}`);
 };

--- a/zapcircle-cli/src/commands/status.ts
+++ b/zapcircle-cli/src/commands/status.ts
@@ -1,14 +1,14 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as toml from "@iarna/toml";
-import { UserConfig, ProjectConfig } from "../types/config";
+import { ProjectConfig, UserConfig } from "../types/config";
 
 export const checkZapCircleStatus = () => {
   const userConfigDir = path.join(require("os").homedir(), ".zapcircle");
   const userConfigPath = path.join(userConfigDir, "zapcircle.cli.toml");
   const projectConfigPath = path.join(process.cwd(), "zapcircle.config.toml");
 
-  console.log("ZapCircle Configuration Status:\n");
+  console.log("📦 ZapCircle Configuration Status:\n");
 
   // Load user-level configuration
   if (fs.existsSync(userConfigPath)) {
@@ -16,45 +16,44 @@ export const checkZapCircleStatus = () => {
       const userConfigData = fs.readFileSync(userConfigPath, "utf-8");
       const userConfig = toml.parse(userConfigData) as UserConfig;
 
-      console.log("User Configuration:");
-      console.log(
-        `  Preferred LLM: ${userConfig.preferredLLM || "Not Configured"}`,
-      );
-      console.log(
-        `  Large Model: ${userConfig.models?.large || "Not Configured"}`,
-      );
-      console.log(
-        `  Small Model: ${userConfig.models?.small || "Not Configured"}`,
-      );
-      console.log(
-        `  API Key: ${userConfig.apiKey ? "Configured" : "Not Configured"}`,
-      );
+      console.log("🔧 User Configuration:");
+      console.log(`  Provider: ${userConfig.provider || "Not Configured"}`);
+      console.log(`  Large Model: ${userConfig.models?.large || "Not Configured"}`);
+      console.log(`  Small Model: ${userConfig.models?.small || "Not Configured"}`);
+
+      console.log("  API Keys:");
+      console.log(`    OpenAI: ${userConfig.openai?.apiKey ? "✅ Configured" : "❌ Not Configured"}`);
+      console.log(`    Anthropic: ${userConfig.anthropic?.apiKey ? "✅ Configured" : "❌ Not Configured"}`);
+      console.log(`    Google: ${userConfig.google?.apiKey ? "✅ Configured" : "❌ Not Configured"}`);
+
+      const localUrl = userConfig.local?.baseUrl;
+      const isValidURL = (url: string) =>
+        /^https?:\/\/[\w.-]+(:\d+)?(\/.*)?$/.test(url);
+
+      console.log(`    Local LLM: ${
+        localUrl ? (isValidURL(localUrl) ? `✅ Configured (${localUrl})` : `⚠️ Invalid URL (${localUrl})`) : "❌ Not Configured"
+      }`);
     } catch (error) {
-      console.error(`Error reading user configuration: ${error}`);
+      console.error(`❌ Error reading user configuration: ${error}`);
     }
   } else {
-    console.log("User Configuration: Not Found");
+    console.log("🔧 User Configuration: ❌ Not Found");
   }
 
   console.log("\n");
 
-  // Check for project-level configuration
+  // Load project-level configuration
   if (fs.existsSync(projectConfigPath)) {
     try {
       const projectConfigData = fs.readFileSync(projectConfigPath, "utf-8");
       const projectConfig = toml.parse(projectConfigData) as ProjectConfig;
 
-      console.log("Project Configuration: Found");
+      console.log("📁 Project Configuration: ✅ Found");
       console.log("  Prompt Settings:");
-      console.log(
-        `    All Prompts: ${projectConfig.prompts?.all || "Not Configured"}`,
-      );
-      console.log(
-        `    Analyze Prompts: ${projectConfig.prompts?.analyze || "Not Configured"}`,
-      );
-      console.log(
-        `    Generate Prompts: ${projectConfig.prompts?.generate || "Not Configured"}`,
-      );
+      console.log(`    All Prompts: ${projectConfig.prompts?.all || "Not Configured"}`);
+      console.log(`    Analyze Prompts: ${projectConfig.prompts?.analyze || "Not Configured"}`);
+      console.log(`    Generate Prompts: ${projectConfig.prompts?.generate || "Not Configured"}`);
+
       console.log("  Filetype Generate Prompts:");
       if (projectConfig["filetype.generate"]) {
         for (const [filetype, setting] of Object.entries(
@@ -66,11 +65,11 @@ export const checkZapCircleStatus = () => {
         console.log("    None Configured");
       }
     } catch (error) {
-      console.error(`Error reading project configuration: ${error}`);
+      console.error(`❌ Error reading project configuration: ${error}`);
     }
   } else {
-    console.log("Project Configuration: Not Found");
+    console.log("📁 Project Configuration: ❌ Not Found");
   }
 
-  console.log("\nStatus check complete.");
+  console.log("\n✅ Status check complete.");
 };

--- a/zapcircle-cli/src/core/CustomLocalLLM.ts
+++ b/zapcircle-cli/src/core/CustomLocalLLM.ts
@@ -1,0 +1,26 @@
+// CustomLocalLLM.ts
+export class CustomLocalLLM {
+    modelName: string;
+    baseUrl: string;
+  
+    constructor(opts: { modelName: string; baseUrl: string }) {
+      this.modelName = opts.modelName;
+      this.baseUrl = opts.baseUrl;
+    }
+  
+    async invoke(prompt: string): Promise<string> {
+      const response = await fetch(`${this.baseUrl}/v1/completions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: this.modelName,
+          prompt,
+        }),
+      });
+  
+      const json = await response.json();
+      return json.completion || json.text || JSON.stringify(json);
+    }
+  }

--- a/zapcircle-cli/src/core/config.ts
+++ b/zapcircle-cli/src/core/config.ts
@@ -1,15 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as toml from "@iarna/toml";
+import { UserConfig } from "../types/config";
 
-export interface UserConfig {
-  preferredLLM?: string;
-  models?: {
-    large?: string;
-    small?: string;
-  };
-  apiKey?: string;
-}
 
 export function loadUserConfig(): UserConfig {
   const userConfigDir = path.join(require("os").homedir(), ".zapcircle");

--- a/zapcircle-cli/src/core/llmProviders.ts
+++ b/zapcircle-cli/src/core/llmProviders.ts
@@ -1,0 +1,41 @@
+// llmProvider.ts
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { CustomLocalLLM } from "./CustomLocalLLM";
+
+export function getLLMClient(config: any, isLarge: boolean) {
+  const provider = config.provider || "openai";
+  const modelName = isLarge
+    ? config.models?.large
+    : config.models?.small;
+
+  switch (provider) {
+    case "openai":
+      return new ChatOpenAI({
+        model: modelName,
+        openAIApiKey: config.openai?.apiKey || process.env.OPENAI_API_KEY,
+      });
+
+    case "anthropic":
+      return new ChatAnthropic({
+        modelName,
+        anthropicApiKey: config.anthropic?.apiKey || process.env.ANTHROPIC_API_KEY,
+      });
+
+    case "google":
+      return new ChatGoogleGenerativeAI({
+        model: modelName,
+        apiKey: config.google?.apiKey || process.env.GOOGLE_API_KEY,
+      });
+
+    case "local":
+      return new CustomLocalLLM({
+        baseUrl: config.local?.baseUrl || "http://localhost:1234",
+        modelName,
+      });
+
+    default:
+      throw new Error(`Unsupported LLM provider: ${provider}`);
+  }
+}

--- a/zapcircle-cli/src/core/llmService.ts
+++ b/zapcircle-cli/src/core/llmService.ts
@@ -12,8 +12,7 @@ export async function invokeLLM(
   const llm = getLLMClient(config, isLarge);
 
   if (isVerbose) {
-    console.log("Provider: " + config.provider || "openai");
-    console.log("Prompt: " + prompt);
+    console.log("Provider: " + (config.provider || "openai"));
   }
 
   const response = await llm.invoke(prompt);

--- a/zapcircle-cli/src/core/llmService.ts
+++ b/zapcircle-cli/src/core/llmService.ts
@@ -1,47 +1,39 @@
-import { ChatOpenAI } from "@langchain/openai";
+// llmService.ts
 import { loadUserConfig } from "./config";
+import { getLLMClient } from "./llmProviders";
 import "dotenv/config";
 
 export async function invokeLLM(
   prompt: string,
   isVerbose: boolean,
   isLarge = false,
-) {
-  const userConfig = loadUserConfig();
+): Promise<string> {
+  const config = loadUserConfig();
+  const llm = getLLMClient(config, isLarge);
 
-  const smallModel = userConfig.models?.small || "gpt-4o-mini";
-  const largeModel = userConfig.models?.large || "gpt-4o";
-  const modelName = isLarge ? largeModel : smallModel;
-
-  // Get the OpenAI API key from configuration or environment variable
-  const openAIKey = userConfig.apiKey || process.env.OPENAI_API_KEY;
-
-  if (!openAIKey) {
-    throw new Error(
-      "OpenAI API key is not configured in zapcircle.cli.toml or the environment.",
-    );
+  if (isVerbose) {
+    console.log("Provider: " + config.provider || "openai");
+    console.log("Prompt: " + prompt);
   }
 
-  const model = new ChatOpenAI({
-    model: modelName,
-    openAIApiKey: openAIKey,
-  });
+  const response = await llm.invoke(prompt);
+  let result: string;
 
-  try {
-    if (isVerbose) {
-      console.log("Model: " + modelName);
-      console.log("Prompt: " + prompt);
-    }
-
-    const response = await model.invoke(prompt);
-    const result = response.content.toString();
-
-    if (isVerbose) {
-      console.log("Response: " + result);
-    }
-    return result;
-  } catch (error) {
-    console.error("Error invoking LLM:", error);
-    throw error;
+  if (typeof response === "string") {
+    result = response;
+  } else if (typeof response?.content === "string") {
+    result = response.content;
+  } else if (Array.isArray(response?.content)) {
+    // Some streaming models (like OpenAI via LangChain) may return a list of chunks
+    result = response.content.map((chunk: any) => chunk?.text || chunk).join("");
+  } else {
+    result = JSON.stringify(response, null, 2); // Fallback for unknown structure
   }
+
+  
+  if (isVerbose) {
+    console.log("Response: " + result);
+  }
+
+  return result;
 }

--- a/zapcircle-cli/src/types/config.ts
+++ b/zapcircle-cli/src/types/config.ts
@@ -1,11 +1,23 @@
 // types/config.ts
 export interface UserConfig {
+  provider?: string;
   preferredLLM?: string;
   models?: {
     large?: string;
     small?: string;
   };
-  apiKey?: string;
+  openai?: {
+    apiKey?: string;
+  };
+  anthropic?: {
+    apiKey?: string;
+  };
+  google?: {
+    apiKey?: string;
+  };
+  local?: {
+    baseUrl?: string;
+  };
 }
 
 export interface ProjectConfig {


### PR DESCRIPTION
Because we use LangChain under the hood, we can support additional providers. The way ZapCircle gets configured changed to support provider/API Key pairs, as well as local LLM support.